### PR TITLE
Allow importing via extension name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,15 +10,14 @@ For when words aren't enough.
 A Markdown extension that looks for things like ``:fa-coffee:`` and replaces
 them with the Font Awesome icon markup.
 
-Add a ``FontAwesomeExtension`` instance to your Markdown call and watch the
+Add ``'fontawesome_markdown'`` to your Markdown call and watch the
 magic unfold:
 
 .. code-block:: python
 
     >>> from markdown import Markdown
-    >>> from fontawesome_markdown import FontAwesomeExtension
 
-    >>> markdown = Markdown(extensions=[FontAwesomeExtension()]
+    >>> markdown = Markdown(extensions=['fontawesome_markdown']
     >>> markdown.convert('i ♥ :fa-coffee:')
     <p>i ♥ <i class="fa fa-coffee"></i></p>
 

--- a/fontawesome_markdown/__init__.py
+++ b/fontawesome_markdown/__init__.py
@@ -1,1 +1,1 @@
-from .main import FontAwesomePattern, FontAwesomeExtension, FontAwesomeException  # NOQA
+from .main import FontAwesomePattern, FontAwesomeExtension, FontAwesomeException, makeExtension  # NOQA

--- a/fontawesome_markdown/main.py
+++ b/fontawesome_markdown/main.py
@@ -29,3 +29,7 @@ class FontAwesomeExtension(Extension):
     def extendMarkdown(self, md, md_globals):
         fontawesome = FontAwesomePattern(fontawesome_pattern)
         md.inlinePatterns.add('fontawesome', fontawesome, '<reference')
+
+
+def makeExtension(*args, **kwargs):
+    return FontAwesomeExtension(*args, **kwargs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,9 +5,9 @@ from markdown import Markdown
 from fontawesome_markdown import FontAwesomeExtension, FontAwesomeException
 
 
-@pytest.fixture
-def fa_markdown():
-    return Markdown(extensions=[FontAwesomeExtension()])
+@pytest.fixture(params=[FontAwesomeExtension(), 'fontawesome_markdown'], ids=["import", "string"])
+def fa_markdown(request):
+    return Markdown(extensions=[request.param])
 
 
 def test_example(fa_markdown):


### PR DESCRIPTION
I use Pelican. Most other MD_EXTENSIONS allow importing via name rather than an actual import.

See [Supporting extension names as strings](https://github.com/waylan/Python-Markdown/wiki/Tutorial:-Writing-Extensions-for-Python-Markdown#supporting-extension-names-as-strings)