### PR TITLE
fix build failure with Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class PyTest(TestCommand):
 
 
 def readme():
-    with open('README.rst') as f:
+    with open('README.rst', encoding='utf-8') as f:
         return f.read()
 
 setup(name='fontawesome-markdown',


### PR DESCRIPTION
Without the change, there is a decoding error:

```
Traceback (most recent call last):
  File "setup.py", line 32, in <module>
    long_description=readme(),
  File "setup.py", line 27, in readme
    return f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 637: ordinal not in range(128)
```
with the change, build and installation works fine.

To reproduce the problem, try installing it using this Dockerfile:

```
FROM ubuntu:18.04
RUN apt-get update && apt-get install -y locales python3-pip

RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
  && locale-gen en_US.utf8 \
  && /usr/sbin/update-locale LANG=en_US.UTF-8

RUN pip3 install --upgrade mkdocs
RUN pip3 install pygments
RUN pip3 install pymdown-extensions
RUN pip3 install python-markdown-math

# this step fails
RUN pip3 install fontawesome_markdown
```