### PR TITLE
Fix deprecation warnings

### DIFF
--- a/fontawesome_markdown/main.py
+++ b/fontawesome_markdown/main.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from markdown.extensions import Extension
-from markdown.inlinepatterns import Pattern
-from markdown.util import etree
+from markdown.inlinepatterns import InlineProcessor
+import xml.etree.ElementTree as etree
 from .icon_list import icons
 import json
 
@@ -23,14 +23,14 @@ class FontAwesomeException(Exception):
     pass
 
 
-class FontAwesomePattern(Pattern):
+class FontAwesomePattern(InlineProcessor):
     'Markdown pattern class for matching things that look like FA icons'
 
-    def handleMatch(self, m):
+    def handleMatch(self, match, data):
         el = etree.Element('i')
-        prefix = m.group(2)
-        icon_name = m.group(3)
-        size = m.group(4)
+        prefix = match.group(1)
+        icon_name = match.group(2)
+        size = match.group(3)
         if icon_name in icons:
             styles = icons[icon_name]
             if not prefix and 'solid' in styles:
@@ -52,7 +52,7 @@ class FontAwesomePattern(Pattern):
             if size:
                 css_class += " " + size
             el.attrib = {'class': css_class}
-            return el
+            return el, match.start(0), match.end(0)
         message = "{0} isn't a FA icon I know about".format(icon_name)
         raise FontAwesomeException(message)
 
@@ -60,9 +60,9 @@ class FontAwesomePattern(Pattern):
 class FontAwesomeExtension(Extension):
     'Pick a good spot for calling the pattern defined above'
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         fontawesome = FontAwesomePattern(fontawesome_pattern)
-        md.inlinePatterns.add('fontawesome', fontawesome, '<reference')
+        md.inlinePatterns.register(fontawesome, 'fontawesome', 175)
 
 
 def makeExtension(*args, **kwargs):


### PR DESCRIPTION
The extension was giving me a bunch of deprecation warnings, so I've fixed them

These were the warnings I had:
```
INFO     -  DeprecationWarning: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.
              File "env/lib/python3.10/site-packages/markdown/util.py", line 475, in __getattr__
                warnings.warn(
              File "env/lib/python3.10/site-packages/fontawesome_markdown/__init__.py", line 1, in
                from .main import FontAwesomePattern, FontAwesomeExtension, FontAwesomeException, makeExtension  # NOQA
INFO     -  DeprecationWarning: Using the add method to register a processor or pattern is deprecated. Use the `register` method instead.
              File "env/lib/python3.10/site-packages/fontawesome_markdown/main.py", line 65, in extendMarkdown
                md.inlinePatterns.add('fontawesome', fontawesome, '<reference')
              File "env/lib/python3.10/site-packages/markdown/util.py", line 462, in add
                warnings.warn(
INFO     -  DeprecationWarning: The 'md_globals' parameter of 'fontawesome_markdown.main.FontAwesomeExtension.extendMarkdown' is deprecated.
              File "env/lib/python3.10/site-packages/markdown/core.py", line 125, in registerExtensions
                ext._extendMarkdown(self)
              File "env/lib/python3.10/site-packages/markdown/extensions/__init__.py", line 82, in _extendMarkdown
                warnings.warn(
```